### PR TITLE
Corregida confirmación de transacción con errores

### DIFF
--- a/Controller/EditLiquidacionComision.php
+++ b/Controller/EditLiquidacionComision.php
@@ -77,7 +77,9 @@ class EditLiquidacionComision extends EditController
             foreach ($docs as $invoice) {
                 $lines = $invoice->getLines();
                 if (false === Calculator::calculate($invoice, $lines, true)) {
-                    throw new Exception('error-calculate-commission', ['%code%' => $invoice->codigo]);
+                    throw new Exception(
+                        $this->toolBox()->i18nLog()->error('error-calculate-commission', ['%code%' => $invoice->codigo])
+                    );
                 }
             }
 

--- a/Controller/EditLiquidacionComision.php
+++ b/Controller/EditLiquidacionComision.php
@@ -76,7 +76,9 @@ class EditLiquidacionComision extends EditController
             // recalculate all business documents and save new totals
             foreach ($docs as $invoice) {
                 $lines = $invoice->getLines();
-                Calculator::calculate($invoice, $lines, true);
+                if (false === Calculator::calculate($invoice, $lines, true)) {
+                    throw new Exception('error-calculate-commission', ['%code%' => $invoice->codigo]);
+                }
             }
 
             // update total to settlement commission

--- a/Translation/ca_ES.json
+++ b/Translation/ca_ES.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rang de descompte és per a tots els agents o per a l'agent seleccionat",
     "company-penalty-info": "Si el rang de descompte és per a totes les empreses o només per a la seleccionada",
+    "error-calculate-commission": "Error en calcular la comissió del document %code%",
     "from-dto": "Per descomptes des",
     "from-penalty-info": "Inici del rang del descompte a què s'aplica la penalització",
     "penalize": "Penalitzar",

--- a/Translation/de_DE.json
+++ b/Translation/de_DE.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "If the discount range is for all agents or for the selected agent",
     "company-penalty-info": "If the discount range is for all companies or only for the selected one",
+    "error-calculate-commission": "Error calculating the commission for document %code%",
     "from-dto": "For discounts from",
     "from-penalty-info": "Beginning of the range of the discount to which the penalty is applied",
     "penalize": "Penalize",

--- a/Translation/es_AR.json
+++ b/Translation/es_AR.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_CL.json
+++ b/Translation/es_CL.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_CO.json
+++ b/Translation/es_CO.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_CR.json
+++ b/Translation/es_CR.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_DO.json
+++ b/Translation/es_DO.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_EC.json
+++ b/Translation/es_EC.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -10,5 +10,6 @@
     "penalty-help-title": "Penalización por hacer descuentos",
     "penalty-penalty-info": "Porcentaje que se resta al porcentaje de comisión sobre la venta. (Introducir un valor positivo)",
     "until-dto": "Hasta descuento",
-    "until-penalty-info": "Fin del rango del descuento al que se aplica la penalización. '100' indica máximo del rango"
+    "until-penalty-info": "Fin del rango del descuento al que se aplica la penalización. '100' indica máximo del rango",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%"
 }

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",
@@ -10,6 +11,5 @@
     "penalty-help-title": "Penalización por hacer descuentos",
     "penalty-penalty-info": "Porcentaje que se resta al porcentaje de comisión sobre la venta. (Introducir un valor positivo)",
     "until-dto": "Hasta descuento",
-    "until-penalty-info": "Fin del rango del descuento al que se aplica la penalización. '100' indica máximo del rango",
-    "error-calculate-commission": "Error al calcular la comisión del documento %code%"
+    "until-penalty-info": "Fin del rango del descuento al que se aplica la penalización. '100' indica máximo del rango"
 }

--- a/Translation/es_GT.json
+++ b/Translation/es_GT.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_MX.json
+++ b/Translation/es_MX.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_PA.json
+++ b/Translation/es_PA.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_PE.json
+++ b/Translation/es_PE.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/es_UY.json
+++ b/Translation/es_UY.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/eu_ES.json
+++ b/Translation/eu_ES.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Deskontu tartea agente guztientzat edo hautatutako agentearentzat bada",
     "company-penalty-info": "Deskontu tartea enpresa guztientzat edo hautatutakoarentzat soilik bada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Deskontuetarako",
     "from-penalty-info": "Penalizazioa aplikatzen zaion deskontuaren tartearen hasiera",
     "penalize": "Penalizatu",

--- a/Translation/fr_FR.json
+++ b/Translation/fr_FR.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/gl_ES.json
+++ b/Translation/gl_ES.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Se o intervalo de desconto é para todos os axentes ou para o axente seleccionado",
     "company-penalty-info": "Se o rango de desconto é para todas as empresas ou só para a seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descontos desde",
     "from-penalty-info": "Inicio do rango do desconto ao que se aplica a penalización",
     "penalize": "Penalizar",

--- a/Translation/it_IT.json
+++ b/Translation/it_IT.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/pt_PT.json
+++ b/Translation/pt_PT.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rango de descuento es para todos los agentes o para el agente seleccionado",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",

--- a/Translation/va_ES.json
+++ b/Translation/va_ES.json
@@ -1,6 +1,7 @@
 {
     "agent-penalty-info": "Si el rang de descompte és per a tots els agents o per a l'agent seleccionat",
     "company-penalty-info": "Si el rango de descuento es para todas las empresas o sólo para la seleccionada",
+    "error-calculate-commission": "Error al calcular la comisión del documento %code%",
     "from-dto": "Para descuentos desde",
     "from-penalty-info": "Inicio del rango del descuento al que se aplica la penalización",
     "penalize": "Penalizar",


### PR DESCRIPTION
Cuando fallaba el recálculo del documento el proceso continua confirmando los cambios, esto provocaba que se confirmarán cambios en el modelo de lineas sin que se modifique la cabecera del documento.