### PR TITLE
Fix DBQuery error

### DIFF
--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -1,4 +1,4 @@
 name = 'Comisiones'
 description = 'Añade comisiones y liquidaciones a los agentes.'
-version = 2.1
+version = 2.11
 min_version = 2025.2


### PR DESCRIPTION
The list of invoices to be settled is a JoinModel so the DbQuery class cannot be used in the view's loadData.
It is used to refactor code, simplifying it according to the new forms of Core 2025.