### PR TITLE
Remove use of Where with JoinModel process

### DIFF
--- a/Controller/EditLiquidacionComision.php
+++ b/Controller/EditLiquidacionComision.php
@@ -208,7 +208,7 @@ class EditLiquidacionComision extends EditController
      */
     protected function getInvoicesFromDataForm(array $data): array
     {
-        if (!isset($data['code'])) {
+        if (false === isset($data['code'])) {
             return [];
         }
 
@@ -226,44 +226,44 @@ class EditLiquidacionComision extends EditController
      *
      * @param array $data
      *
-     * @return array[]
+     * @return DataBaseWhere[]
      */
     protected function getInvoicesWhere(array $data): array
     {
         // Basic data filter
         $where = [
-            Where::column('facturascli.idempresa', $data['idempresa']),
-            Where::column('facturascli.codserie', $data['codserie']),
-            Where::column('facturascli.codagente', $data['codagente'])
+            new DataBaseWhere('facturascli.idempresa', $data['idempresa']),
+            new DataBaseWhere('facturascli.codserie', $data['codserie']),
+            new DataBaseWhere('facturascli.codagente', $data['codagente']),
         ];
 
         // Date filter
-        if (!empty($data['datefrom'])) {
-            $where[] = Where::column('facturascli.fecha', $data['datefrom'], '>=');
+        if (false === empty($data['datefrom'])) {
+            $where[] = new DataBaseWhere('facturascli.fecha', $data['datefrom'], '>=');
         }
-        if (!empty($data['dateto'])) {
-            $where[] = Where::column('facturascli.fecha', $data['dateto'], '<=');
+        if (false === empty($data['dateto'])) {
+            $where[] = new DataBaseWhere('facturascli.fecha', $data['dateto'], '<=');
         }
 
         // Status payment filter
-        if ($data['status'] == self::INSERT_STATUS_CHARGED) {
-            $where[] = Where::column('facturascli.pagada', true);
+        if ($data['status'] === self::INSERT_STATUS_CHARGED) {
+            $where[] = new DataBaseWhere('facturascli.pagada', true);
         }
 
         // Payment source filter
         switch ($data['domiciled']) {
             case self::INSERT_DOMICILED_DOMICILED:
-                $where[] = Where::column('formaspago.domiciliado', true);
+                $where[] = new DataBaseWhere('formaspago.domiciliado', true);
                 break;
 
             case self::INSERT_DOMICILED_WITHOUT:
-                $where[] = Where::column('formaspago.domiciliado', false);
+                $where[] = new DataBaseWhere('formaspago.domiciliado', false);
                 break;
         }
 
         // Customer filter
-        if (!empty($data['codcliente'])) {
-            $where[] = Where::column('facturascli.codcliente', $data['codcliente']);
+        if (false === empty($data['codcliente'])) {
+            $where[] = new DataBaseWhere('facturascli.codcliente', $data['codcliente']);
         }
 
         // Return completed filter
@@ -278,9 +278,11 @@ class EditLiquidacionComision extends EditController
         $data = $this->request->request->all();
 
         // add new invoice to settlement commission
-        $where = $this->getInvoicesWhere($data);
-        $settleinvoice = new LiquidacionComisionFactura();
-        $settleinvoice->addInvoiceToSettle($data['idliquidacion'], $where);
+        $settleInvoice = new LiquidacionComisionFactura();
+        $settleInvoice->addInvoiceToSettle(
+            $data['idliquidacion'],
+            $this->getInvoicesWhere($data)
+        );
 
         // update total to settlement commission
         return $this->calculateTotalCommission();

--- a/Model/Join/LiquidacionComisionFactura.php
+++ b/Model/Join/LiquidacionComisionFactura.php
@@ -20,9 +20,10 @@
 namespace FacturaScripts\Plugins\Comisiones\Model\Join;
 
 use Exception;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\KernelException;
 use FacturaScripts\Core\Model\Base\JoinModel;
 use FacturaScripts\Core\Tools;
-use FacturaScripts\Core\Where;
 use FacturaScripts\Dinamic\Model\FacturaCliente;
 
 /**
@@ -35,6 +36,12 @@ use FacturaScripts\Dinamic\Model\FacturaCliente;
  */
 class LiquidacionComisionFactura extends JoinModel
 {
+    /**
+     * Class constructor.
+     * Sets the master model to FacturaCliente.
+     *
+     * @param array $data
+     */
     public function __construct(array $data = [])
     {
         parent::__construct($data);
@@ -46,11 +53,12 @@ class LiquidacionComisionFactura extends JoinModel
      * according to the where filter.
      *
      * @param int $settled
-     * @param array[] $where
+     * @param DataBaseWhere[] $where
+     * @throws KernelException
      */
-    public function addInvoiceToSettle($settled, $where): void
+    public function addInvoiceToSettle(int $settled, array $where): void
     {
-        $where[] = Where::column('facturascli.idliquidacion', null, 'IS');
+        $where[] = new DataBaseWhere('facturascli.idliquidacion', null, 'IS');
         $invoices = $this->all($where);
         if (empty($invoices)) {
             return;
@@ -74,6 +82,11 @@ class LiquidacionComisionFactura extends JoinModel
         }
     }
 
+    /**
+     * Remove the invoice from the settlement.
+     *
+     * @throws KernelException
+     */
     public function delete(): bool
     {
         $sql = 'UPDATE ' . FacturaCliente::tableName() . ' SET idliquidacion = NULL'
@@ -86,7 +99,7 @@ class LiquidacionComisionFactura extends JoinModel
      *
      * @return int
      */
-    public function primaryColumnValue()
+    public function primaryColumnValue(): int
     {
         return $this->idfactura;
     }

--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -1,4 +1,4 @@
 name = 'Comisiones'
 description = 'Añade comisiones y liquidaciones a los agentes.'
-version = 2.11
-min_version = 2025.2
+version = 2.12
+min_version = 2025.5


### PR DESCRIPTION
When selecting invoices for commission settlement, a join model is used, so it is not possible to use the new Where class.