### PR TITLE
Modificar la importación de JoinModel en LiquidacionComisionFactura.php

### DIFF
--- a/Model/Join/LiquidacionComisionFactura.php
+++ b/Model/Join/LiquidacionComisionFactura.php
@@ -22,7 +22,7 @@ namespace FacturaScripts\Plugins\Comisiones\Model\Join;
 use Exception;
 use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\KernelException;
-use FacturaScripts\Core\Model\Base\JoinModel;
+use FacturaScripts\Core\Template\JoinModel;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Dinamic\Model\FacturaCliente;
 


### PR DESCRIPTION
https://facturascripts.com/roadmap/4707
Se actualiza la importación de JoinModel para utilizar la clase correcta desde FacturaScripts\Core\Template en lugar de FacturaScripts\Core\Model\Base. Este cambio asegura la correcta funcionalidad del modelo en el contexto de la liquidación de comisiones.